### PR TITLE
Changes necessary to make nautypy work

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ suffix = 'nautypy'
 build_includedir = include_directories('include')
 
 #-----Specify dependencies-----#
-nauty_dep = dependency('nauty')
+nauty_dep = dependency('libnauty')
 
 #-----Execute subdirectory builds-----#
 #Install headers

--- a/python/nautypy/cffibuild_nautypy.py
+++ b/python/nautypy/cffibuild_nautypy.py
@@ -2,8 +2,8 @@ import path
 from cffi import FFI
 ffibuilder = FFI()
 
-lib_path = path.Path("../../build/src").abspath()
-include_path = path.Path("../../include").abspath()
+lib_path = path.Path("../../build/src").absolute()
+include_path = path.Path("../../include").absolute()
 
 
 ffibuilder.set_source(

--- a/src/nautypy.c
+++ b/src/nautypy.c
@@ -3,20 +3,27 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <threads.h>
+
+static thread_local int* n_auts_g = NULL;
+static thread_local int*** auts_g = NULL;
+
+void store_auts(int count, int* perm, int* orbits, int numorbits, int stabvertex, int n)
+{
+	*n_auts_g = *n_auts_g + 1;
+	*auts_g = realloc(*auts_g,(*n_auts_g)*(sizeof (int*)));
+	(*auts_g)[*n_auts_g-1] = malloc(n*sizeof(int));	
+	memcpy((*auts_g)[*n_auts_g-1],perm,n*sizeof(int));
+}
 
 void canonize(int _nv, size_t _nde, size_t* _v, int* _d, int* _e, int* lab, int* ptn, int* n_auts, int*** auts)
 {
-	*n_auts = 0;	
-	
-	*auts = NULL;
 
-	void store_auts(int count, int* perm, int* orbits, int numorbits, int stabvertex, int n)
-	{
-		*n_auts = *n_auts + 1;
-		*auts = realloc(*auts,(*n_auts)*(sizeof (int*)));
-		(*auts)[*n_auts-1] = malloc(n*sizeof(int));	
-		memcpy((*auts)[*n_auts-1],perm,n*sizeof(int));
-	}
+	n_auts_g = n_auts;
+	*n_auts_g = 0;
+	
+	auts_g = auts;
+	*auts_g = NULL;
 
     DYNALLSTAT(int,orbits,orbits_sz);
     static DEFAULTOPTIONS_SPARSEGRAPH(options);


### PR DESCRIPTION
Because of breaking changes in the dependencies I had to do small modifications of nautypy to make it work properly:

* The name of the nauty shared library is now "libnauty"
* Nested functions require executable stack, which is now unsupported in shared libraries if the main program doesn't use it https://sourceware.org/pipermail/libc-alpha/2024-December/163146.html
* IDK I think Path changed API?